### PR TITLE
Fixed url in css files.  "url(//" --> "url(https://"

### DIFF
--- a/css/adoc-colony.css
+++ b/css/adoc-colony.css
@@ -1,4 +1,4 @@
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-foundation-lime.css
+++ b/css/adoc-foundation-lime.css
@@ -1,4 +1,4 @@
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-foundation-potion.css
+++ b/css/adoc-foundation-potion.css
@@ -1,4 +1,4 @@
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-foundation.css
+++ b/css/adoc-foundation.css
@@ -1,4 +1,4 @@
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-github.css
+++ b/css/adoc-github.css
@@ -1,4 +1,4 @@
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-golo.css
+++ b/css/adoc-golo.css
@@ -1,5 +1,5 @@
-@import url(//fonts.googleapis.com/css?family=Varela+Round|Open+Sans:400italic,700italic,400,700);
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://fonts.googleapis.com/css?family=Varela+Round|Open+Sans:400italic,700italic,400,700);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-iconic.css
+++ b/css/adoc-iconic.css
@@ -1,5 +1,5 @@
-@import url(//fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic);
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* Inspired by the O'Reilly typography and the Atlas user manual | https://oreilly.com */
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */

--- a/css/adoc-maker.css
+++ b/css/adoc-maker.css
@@ -1,5 +1,5 @@
-@import url(//fonts.googleapis.com/css?family=Glegoo);
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://fonts.googleapis.com/css?family=Glegoo);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-readthedocs.css
+++ b/css/adoc-readthedocs.css
@@ -1,4 +1,4 @@
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-riak.css
+++ b/css/adoc-riak.css
@@ -1,6 +1,6 @@
-@import url(//fonts.googleapis.com/css?family=Titillium+Web:400,700);
-@import url(//fonts.googleapis.com/css?family=Noticia+Text:400,400italic);
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400,700);
+@import url(https://fonts.googleapis.com/css?family=Noticia+Text:400,400italic);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* Derived from the Riak documentation theme developed by Basho Technologies, Inc. | CC BY 3.0 License | https://docs.basho.org */
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */

--- a/css/adoc-rocket-panda.css
+++ b/css/adoc-rocket-panda.css
@@ -1,5 +1,5 @@
-@import url(//openshift.redhat.com/app/assets-20130701203230/overpass.css);
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://openshift.redhat.com/app/assets-20130701203230/overpass.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/adoc-rubygems.css
+++ b/css/adoc-rubygems.css
@@ -1,4 +1,4 @@
-@import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/css/clean.css
+++ b/css/clean.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url("//fonts.googleapis.com/css?family=Noto+Sans:300,600italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700");
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url("https://fonts.googleapis.com/css?family=Noto+Sans:300,600italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700");
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/dark.css
+++ b/css/dark.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/fedora.css
+++ b/css/fedora.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Montserrat|Open+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Montserrat|Open+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/gazette.css
+++ b/css/gazette.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Source+Serif+Pro|UnifrakturMaguntia|Source+Sans+Pro);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Source+Serif+Pro|UnifrakturMaguntia|Source+Sans+Pro);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/italian-pop.css
+++ b/css/italian-pop.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Galada|Lato);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Galada|Lato);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-amber.css
+++ b/css/material-amber.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-blue.css
+++ b/css/material-blue.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-brown.css
+++ b/css/material-brown.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-green.css
+++ b/css/material-green.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-grey.css
+++ b/css/material-grey.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-orange.css
+++ b/css/material-orange.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-pink.css
+++ b/css/material-pink.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-purple.css
+++ b/css/material-purple.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-red.css
+++ b/css/material-red.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/material-teal.css
+++ b/css/material-teal.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/monospace.css
+++ b/css/monospace.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
 @import url("https://fonts.googleapis.com/css?family=Source+Code+Pro");
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/notebook.css
+++ b/css/notebook.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Cabin+Sketch|Architects+Daughter);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Cabin+Sketch|Architects+Daughter);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/plain.css
+++ b/css/plain.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Noto+Sans);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */

--- a/css/ubuntu.css
+++ b/css/ubuntu.css
@@ -1,7 +1,7 @@
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 
-@import url(//fonts.googleapis.com/css?family=Ubuntu);
-@import url(//asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
+@import url(https://fonts.googleapis.com/css?family=Ubuntu);
+@import url(https://asciidoctor.org/stylesheets/asciidoctor.css); /* Default asciidoc style framework - important */
 
 /* CUSTOMISATIONS */
 /* Change the values in root for quick customisation. If you want even more fine grain... venture further. */


### PR DESCRIPTION
Thanks much for these Asciidoctor skins.  However ...

When I did the following:

`$ asciidoctor -a toc2 -a stylesheet=css/ubuntu.css myfile.txt`

I was not getting a sidebar with the toc in it.

I read the discussion of issue #27 https://github.com/darshandsoni/asciidoctor-skins/issues/27

So, I have changed all the ocurances of "url(//" to "url(https://".
I could not find where that has been fixed.

Could you please look at this PR and merge it if you agree that it fixes the problem correctly.

Thanks

Dave
