### PR TITLE
Fix golo theme background

### DIFF
--- a/css/adoc-golo.css
+++ b/css/adoc-golo.css
@@ -122,7 +122,7 @@ table { border-collapse: collapse; border-spacing: 0; }
 
 html, body { font-size: 100%; }
 
-body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
+body { color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
 a:hover { cursor: pointer; }
 
@@ -623,7 +623,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 .conum:after { content: attr(data-value); }
 .conum:not([data-value]):empty { display: none; }
 
-body { background: url('../images/golo/body-bg.png?1364899918') #fdfaf7 repeat; }
+html { background: url('../images/golo/body-bg.png?1364899918') #fdfaf7 repeat; }
 
 #toc.toc2 ol ol { list-style-type: circle; padding-left: 1.75em; }
 


### PR DESCRIPTION
The background is applied to `body`, not `html`. This causes the background color to not work for pages with little content, such as the AsciiDoctor sample text.

Before:
![old](https://user-images.githubusercontent.com/3249268/78818600-731c3200-79c4-11ea-820f-585edbecc3a0.png)

After:
![new](https://user-images.githubusercontent.com/3249268/78818690-96df7800-79c4-11ea-8f63-3fd181ad2898.png)

Other themes with non-white backgrounds may or may not also have this problem.